### PR TITLE
Add Magic Leap Controller Support

### DIFF
--- a/src/components/hand-controls.js
+++ b/src/components/hand-controls.js
@@ -202,6 +202,7 @@ module.exports.Component = registerComponent('hand-controls', {
         el.setObject3D('mesh', mesh);
         mesh.position.set(0, 0, 0);
         mesh.rotation.set(0, 0, handModelOrientation);
+        el.setAttribute('magicleap-controls', controlConfiguration);
         el.setAttribute('vive-controls', controlConfiguration);
         el.setAttribute('oculus-touch-controls', controlConfiguration);
         el.setAttribute('windows-motion-controls', controlConfiguration);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,6 +12,7 @@ require('./light');
 require('./line');
 require('./link');
 require('./look-controls');
+require('./magicleap-controls');
 require('./material');
 require('./obj-model');
 require('./oculus-go-controls');

--- a/src/components/laser-controls.js
+++ b/src/components/laser-controls.js
@@ -18,6 +18,7 @@ registerComponent('laser-controls', {
     // Set all controller models.
     el.setAttribute('daydream-controls', controlsConfiguration);
     el.setAttribute('gearvr-controls', controlsConfiguration);
+    el.setAttribute('magicleap-controls', controlsConfiguration);
     el.setAttribute('oculus-go-controls', controlsConfiguration);
     el.setAttribute('oculus-touch-controls', controlsConfiguration);
     el.setAttribute('vive-controls', controlsConfiguration);
@@ -82,6 +83,10 @@ registerComponent('laser-controls', {
 
     'generic-tracked-controller-controls': {
       cursor: {downEvents: ['triggerdown'], upEvents: ['triggerup']}
+    },
+
+    'magicleap-controls': {
+      cursor: {downEvents: ['trackpaddown', 'triggerdown'], upEvents: ['trackpadup', 'triggerup']}
     },
 
     'oculus-go-controls': {

--- a/src/components/magicleap-controls.js
+++ b/src/components/magicleap-controls.js
@@ -1,0 +1,178 @@
+var bind = require('../utils/bind');
+var registerComponent = require('../core/component').registerComponent;
+
+var trackedControlsUtils = require('../utils/tracked-controls');
+var checkControllerPresentAndSetup = trackedControlsUtils.checkControllerPresentAndSetup;
+var emitIfAxesChanged = trackedControlsUtils.emitIfAxesChanged;
+var onButtonEvent = trackedControlsUtils.onButtonEvent;
+
+// See Profiles Registry:
+// https://github.com/immersive-web/webxr-input-profiles/tree/master/packages/registry
+// TODO: Add a more robust system for deriving gamepad name.
+var GAMEPAD_ID_PREFIX = 'magicleap';
+var GAMEPAD_ID_SUFFIX = '-one';
+var GAMEPAD_ID_COMPOSITE = GAMEPAD_ID_PREFIX + GAMEPAD_ID_SUFFIX;
+
+var MAGICLEAP_CONTROLLER_MODEL_GLB_URL = 'https://cdn.aframe.io/controllers/magicleap/magicleap-one-controller.glb';
+
+/**
+ * Button IDs:
+ * 0 - trigger
+ * 1 - grip
+ * 2 - touchpad
+ * 3 - menu (never dispatched on this layer)
+ *
+ * Axis:
+ * 0 - touchpad x axis
+ * 1 - touchpad y axis
+ */
+var INPUT_MAPPING_WEBXR = {
+  axes: {touchpad: [0, 1]},
+  buttons: ['trigger', 'grip', 'touchpad', 'menu']
+};
+
+/**
+ * Magic Leap Controls
+ * Interface with Magic Leap control and map Gamepad events to controller
+ * buttons: trigger, grip, touchpad, and menu.
+ * Load a controller model.
+ */
+module.exports.Component = registerComponent('magicleap-controls', {
+  schema: {
+    hand: {default: 'none'},
+    model: {default: true},
+    orientationOffset: {type: 'vec3'}
+  },
+
+  mapping: INPUT_MAPPING_WEBXR,
+
+  init: function () {
+    var self = this;
+    this.controllerPresent = false;
+    this.lastControllerCheck = 0;
+    this.onButtonChanged = bind(this.onButtonChanged, this);
+    this.onButtonDown = function (evt) { onButtonEvent(evt.detail.id, 'down', self); };
+    this.onButtonUp = function (evt) { onButtonEvent(evt.detail.id, 'up', self); };
+    this.onButtonTouchEnd = function (evt) { onButtonEvent(evt.detail.id, 'touchend', self); };
+    this.onButtonTouchStart = function (evt) { onButtonEvent(evt.detail.id, 'touchstart', self); };
+    this.previousButtonValues = {};
+    this.rendererSystem = this.el.sceneEl.systems.renderer;
+
+    this.bindMethods();
+  },
+
+  update: function () {
+    var data = this.data;
+    this.controllerIndex = data.hand === 'right' ? 0 : data.hand === 'left' ? 1 : 2;
+  },
+
+  play: function () {
+    this.checkIfControllerPresent();
+    this.addControllersUpdateListener();
+  },
+
+  pause: function () {
+    this.removeEventListeners();
+    this.removeControllersUpdateListener();
+  },
+
+  bindMethods: function () {
+    this.onModelLoaded = bind(this.onModelLoaded, this);
+    this.onControllersUpdate = bind(this.onControllersUpdate, this);
+    this.checkIfControllerPresent = bind(this.checkIfControllerPresent, this);
+    this.removeControllersUpdateListener = bind(this.removeControllersUpdateListener, this);
+    this.onAxisMoved = bind(this.onAxisMoved, this);
+  },
+
+  addEventListeners: function () {
+    var el = this.el;
+    el.addEventListener('buttonchanged', this.onButtonChanged);
+    el.addEventListener('buttondown', this.onButtonDown);
+    el.addEventListener('buttonup', this.onButtonUp);
+    el.addEventListener('touchstart', this.onButtonTouchStart);
+    el.addEventListener('touchend', this.onButtonTouchEnd);
+    el.addEventListener('axismove', this.onAxisMoved);
+    el.addEventListener('model-loaded', this.onModelLoaded);
+    this.controllerEventsActive = true;
+  },
+
+  removeEventListeners: function () {
+    var el = this.el;
+    el.removeEventListener('buttonchanged', this.onButtonChanged);
+    el.removeEventListener('buttondown', this.onButtonDown);
+    el.removeEventListener('buttonup', this.onButtonUp);
+    el.removeEventListener('touchstart', this.onButtonTouchStart);
+    el.removeEventListener('touchend', this.onButtonTouchEnd);
+    el.removeEventListener('axismove', this.onAxisMoved);
+    el.removeEventListener('model-loaded', this.onModelLoaded);
+    this.controllerEventsActive = false;
+  },
+
+  checkIfControllerPresent: function () {
+    var data = this.data;
+    checkControllerPresentAndSetup(this, GAMEPAD_ID_COMPOSITE,
+                                   {index: this.controllerIndex, hand: data.hand});
+  },
+
+  injectTrackedControls: function () {
+    var el = this.el;
+    var data = this.data;
+
+    el.setAttribute('tracked-controls', {
+      // TODO: verify expected behavior between reserved prefixes.
+      idPrefix: GAMEPAD_ID_COMPOSITE,
+      hand: data.hand,
+      controller: this.controllerIndex,
+      orientationOffset: data.orientationOffset
+    });
+
+    // Load model.
+    if (!this.data.model) { return; }
+    this.el.setAttribute('gltf-model', MAGICLEAP_CONTROLLER_MODEL_GLB_URL);
+  },
+
+  addControllersUpdateListener: function () {
+    this.el.sceneEl.addEventListener('controllersupdated', this.onControllersUpdate, false);
+  },
+
+  removeControllersUpdateListener: function () {
+    this.el.sceneEl.removeEventListener('controllersupdated', this.onControllersUpdate, false);
+  },
+
+  onControllersUpdate: function () {
+    // Note that due to gamepadconnected event propagation issues, we don't rely on events.
+    this.checkIfControllerPresent();
+  },
+
+  /**
+   * Rotate the trigger button based on how hard the trigger is pressed.
+   */
+  onButtonChanged: function (evt) {
+    var button = this.mapping.buttons[evt.detail.id];
+    var analogValue;
+
+    if (!button) { return; }
+    if (button === 'trigger') {
+      analogValue = evt.detail.state.value;
+      console.log('analog value of trigger press: ' + analogValue);
+    }
+
+    // Pass along changed event with button state, using button mapping for convenience.
+    this.el.emit(button + 'changed', evt.detail.state);
+  },
+
+  onModelLoaded: function (evt) {
+    var controllerObject3D = evt.detail.model;
+    // our glb scale is too large.
+    controllerObject3D.scale.set(0.01, 0.01, 0.01);
+  },
+
+  onAxisMoved: function (evt) {
+    emitIfAxesChanged(this, this.mapping.axes, evt);
+  },
+
+  updateModel: function (buttonName, evtName) {},
+
+  setButtonColor: function (buttonName, color) {}
+
+});

--- a/src/components/tracked-controls-webxr.js
+++ b/src/components/tracked-controls-webxr.js
@@ -61,9 +61,18 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
     sceneEl.xrSession.removeEventListener('selectend', this.emitButtonUpEvent);
   },
 
+  isControllerPresent: function (evt) {
+    if (!this.controller || this.controller.gamepad) { return false; }
+    if (evt.inputSource.handedness !== 'none' &&
+        evt.inputSource.handedness !== this.data.hand) {
+      return false;
+    }
+    return true;
+  },
+
   emitButtonDownEvent: function (evt) {
-    if (!this.controller || evt.inputSource.handedness !== this.data.hand) { return; }
-    if (this.controller.gamepad) { return; }
+    if (!this.isControllerPresent(evt)) { return; }
+
     this.selectEventDetails.state.pressed = true;
     this.el.emit('buttondown', this.selectEventDetails);
     this.el.emit('buttonchanged', this.selectEventDetails);
@@ -71,8 +80,8 @@ module.exports.Component = registerComponent('tracked-controls-webxr', {
   },
 
   emitButtonUpEvent: function (evt) {
-    if (!this.controller || evt.inputSource.handedness !== this.data.hand) { return; }
-    if (this.controller.gamepad) { return; }
+    if (!this.isControllerPresent(evt)) { return; }
+
     this.selectEventDetails.state.pressed = false;
     this.el.emit('buttonup', this.selectEventDetails);
     this.el.emit('buttonchanged', this.selectEventDetails);

--- a/src/systems/tracked-controls-webxr.js
+++ b/src/systems/tracked-controls-webxr.js
@@ -19,7 +19,15 @@ module.exports.System = registerSystem('tracked-controls-webxr', {
   updateControllerList: function () {
     var xrSession = this.el.xrSession;
     var self = this;
-    if (!xrSession) { return; }
+    if (!xrSession) {
+      if (this.oldControllersLength === 0) { return; }
+      // Broadcast that we now have zero controllers connected if there is
+      // no session
+      this.oldControllersLength = 0;
+      this.controllers = [];
+      this.el.emit('controllersupdated', undefined, false);
+      return;
+    }
     this.controllers = this.el.xrSession.inputSources;
     if (this.oldControllersLength === this.controllers.length) { return; }
     this.oldControllersLength = this.controllers.length;


### PR DESCRIPTION
This pull request addresses three issues.

One, defines the Magic Leap Component to support the new XR session profiles.
Two, addresses an issue where the controllers are being cached, despite closing the XRsession, and so when requesting a new session, chromium/webxr rejects the session due to the previous, now invalid, session id stored in the controller.
Three, based on available documentation for XRHandedness, there is support for input devices that do not specify a specific "handedness".  This should be accounted for and allow these input events to still send button events.

References:
https://immersive-web.github.io/webxr-reference/webxr-device-api/xrinputsource.html
https://chromium.googlesource.com/chromium/src/+/ab6c1c84a115d5a05c6827de7a33b70fbbb8e5ea/device/vr/public/mojom/vr_service.mojom